### PR TITLE
fix(step-01.1): allow UTF-8 in docs guard

### DIFF
--- a/tools/guards/docs_guard.ps1
+++ b/tools/guards/docs_guard.ps1
@@ -1,17 +1,17 @@
 $ErrorActionPreference = "Stop"
 
-$docs = Get-ChildItem -Path (Join-Path $PSScriptRoot '..' '..' 'docs') -Recurse -Filter '*.md'
-foreach ($doc in $docs) {
-    $lines = Get-Content -Path $doc.FullName
-    if ($lines -match 'TODO') {
-        throw "TODO found in $($doc.FullName)"
-    }
-
-    foreach ($line in $lines) {
-        if ($line.ToCharArray() | Where-Object { [int]$_ -gt 127 }) {
-            throw "Non-ASCII character detected in $($doc.FullName)"
-        }
-    }
+$docsPath = Join-Path $PSScriptRoot '..' '..' 'docs'
+if (-not (Test-Path $docsPath)) {
+    throw "Docs directory not found at $docsPath"
 }
 
-Write-Host 'docs_guard OK'
+$docs = Get-ChildItem -Path $docsPath -Recurse -Filter '*.md'
+foreach ($doc in $docs) {
+    $content = Get-Content -Path $doc.FullName -Raw
+    if ($content -match 'TODO') {
+        throw "TODO found in $($doc.FullName)"
+    }
+    # UTF-8 allowed: no ASCII enforcement for docs content
+}
+
+Write-Host 'docs_guard OK (UTF-8 allowed in docs)'


### PR DESCRIPTION
## Summary
- allow the documentation guard to accept UTF-8 characters while keeping TODO detection
- add an explicit docs directory check and clarify the guard success message

## Testing
- ⚠️ `pwsh -File tools/guards/run_all_guards.ps1` *(PowerShell is unavailable in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d17bf6dcd4833090c9d32f2ae1e07f