### PR TITLE
Implement roadmap step-02 guard automation

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,13 @@
 ## Summary
-- ...
+
+- Describe the change...
+
+## Roadmap Reference
+
+- Paste the roadmap step reference below (required):
+
+Ref: docs/roadmap/step-02.md
 
 ## Testing
-- ...
 
-Ref: docs/roadmap/step-01.md
+- How did you test this change?

--- a/.github/workflows/guards.yml
+++ b/.github/workflows/guards.yml
@@ -1,12 +1,19 @@
 name: Codex CI / guards
 
-on: [pull_request]
+on:
+  push:
+  pull_request:
 
 jobs:
   guards:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: Run guards
         shell: pwsh
+        env:
+          PR_BODY: ${{ github.event.pull_request.body || '' }}
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
         run: ./tools/guards/run_all_guards.ps1

--- a/docs/guards/README.md
+++ b/docs/guards/README.md
@@ -1,0 +1,16 @@
+# Guards - Quick Troubleshooting
+
+## Error: Missing 'Ref: docs/roadmap/step-02.md' in PR or last commit
+
+**Fix locally:**
+
+```powershell
+./tools/ci/ensure_roadmap_ref.ps1 -RepoSlug "<owner>/<repo>" -Branch "<your-branch>"
+```
+
+This will:
+- create an empty commit with the roadmap reference if missing,
+- push (SSH, fallback to HTTPS if needed),
+- update the PR body with the same reference when possible.
+
+Also ensure your PR uses the template and keeps the `Ref:` line.

--- a/docs/roadmap/step-02.md
+++ b/docs/roadmap/step-02.md
@@ -372,3 +372,9 @@ Constraints:
 
 END
 
+---
+
+## Validation
+
+VALIDATE? yes/no
+

--- a/tools/ci/ensure_roadmap_ref.ps1
+++ b/tools/ci/ensure_roadmap_ref.ps1
@@ -1,0 +1,114 @@
+param(
+    [string]$RefLine = 'Ref: docs/roadmap/step-02.md',
+    [string]$RepoSlug = '',
+    [string]$Branch = ''
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Ensure-OriginRemote {
+    param([string]$slug)
+
+    if (-not $slug) {
+        return $null
+    }
+
+    $current = git remote get-url origin 2>$null
+    if (-not $current) {
+        Write-Host 'Configuring origin (SSH)...'
+        git remote add origin ("git@github.com:{0}.git" -f $slug)
+        $current = git remote get-url origin
+    }
+
+    return $current
+}
+
+function Commit-EnsureRefLine {
+    param([string]$line)
+
+    $message = ''
+    try {
+        $message = git log -1 --pretty=%B 2>$null
+    } catch {
+        $message = ''
+    }
+
+    if (-not $message) {
+        Write-Host 'Repository has no commits yet. Creating initial empty commit with roadmap reference...'
+        git commit --allow-empty -m $line
+        return
+    }
+
+    if ($message -notmatch [regex]::Escape($line)) {
+        Write-Host 'Adding empty commit with roadmap reference...'
+        git commit --allow-empty -m $line
+    } else {
+        Write-Host 'Last commit already contains roadmap reference.'
+    }
+}
+
+function Push-WithFallback {
+    param([string]$branch)
+
+    if ($branch) {
+        git push -u origin $branch
+    } else {
+        git push
+    }
+
+    if ($LASTEXITCODE -eq 0) {
+        return
+    }
+
+    Write-Warning 'SSH push failed. Switching origin to HTTPS...'
+    $url = git remote get-url origin 2>$null
+    if ($url -like 'git@github.com:*') {
+        $slug = $url -replace '^git@github.com:', '' -replace '\.git$', ''
+        git remote set-url origin ("https://github.com/{0}.git" -f $slug)
+    }
+
+    if ($branch) {
+        git push -u origin $branch
+    } else {
+        git push
+    }
+}
+
+function Ensure-PRBodyRef {
+    param([string]$line)
+
+    try {
+        gh --version *> $null
+    } catch {
+        Write-Warning 'gh CLI not available; skipping PR body update.'
+        return
+    }
+
+    $prNumber = gh pr view --json number -q .number 2>$null
+    if (-not $prNumber) {
+        Write-Warning 'No PR detected; skipping PR body update.'
+        return
+    }
+
+    $body = gh pr view --json body -q .body
+    if ($body -notmatch [regex]::Escape($line)) {
+        $newBody = ($body + "`n`n" + $line).Trim()
+        $tempFile = Join-Path $env:TEMP 'pr_body_with_ref.txt'
+        $newBody | Out-File -Encoding UTF8 -FilePath $tempFile
+        gh pr edit $prNumber --body-file $tempFile
+        Remove-Item $tempFile -ErrorAction SilentlyContinue
+        Write-Host 'PR body updated with roadmap reference.'
+    } else {
+        Write-Host 'PR body already contains roadmap reference.'
+    }
+}
+
+if ($RepoSlug) {
+    Ensure-OriginRemote -slug $RepoSlug | Out-Null
+}
+
+Commit-EnsureRefLine -line $RefLine
+Push-WithFallback -branch $Branch
+Ensure-PRBodyRef -line $RefLine
+
+Write-Host 'Done.'

--- a/tools/guards/roadmap_guard.ps1
+++ b/tools/guards/roadmap_guard.ps1
@@ -2,7 +2,31 @@ param(
     [switch]$Strict
 )
 
-$ErrorActionPreference = "Stop"
+$ErrorActionPreference = 'Stop'
+
+$requiredRef = 'Ref: docs/roadmap/step-02.md'
+
+function Get-LastCommitMessage {
+    git log -1 --pretty=%B
+}
+
+function Get-PRBody {
+    if ($env:PR_BODY) {
+        return $env:PR_BODY
+    }
+
+    if ($env:GITHUB_EVENT_NAME -eq 'pull_request') {
+        try {
+            $body = gh pr view --json body -q .body 2>$null
+            if ($LASTEXITCODE -eq 0 -and $body) {
+                return $body
+            }
+        } catch {
+        }
+    }
+
+    return ''
+}
 
 $roadmapPath = Join-Path $PSScriptRoot '..' '..' 'docs' 'roadmap'
 if (-not (Test-Path $roadmapPath)) {
@@ -25,4 +49,26 @@ foreach ($file in $files) {
     }
 }
 
-Write-Host 'roadmap_guard OK'
+$commitMessage = Get-LastCommitMessage
+if (-not $commitMessage) {
+    throw 'Unable to read last commit message.'
+}
+
+if ($commitMessage -notmatch [regex]::Escape($requiredRef)) {
+    throw ("Missing roadmap reference in LAST COMMIT. Expected line: `"{0}`"" -f $requiredRef)
+}
+
+$prBody = Get-PRBody
+if ($env:GITHUB_EVENT_NAME -eq 'pull_request') {
+    if (-not $prBody) {
+        throw ("PR body not available to verify required roadmap reference: {0}" -f $requiredRef)
+    } elseif ($prBody -notmatch [regex]::Escape($requiredRef)) {
+        throw ("Missing roadmap reference in PR BODY. Expected line: `"{0}`"" -f $requiredRef)
+    }
+} elseif ($prBody) {
+    if ($prBody -notmatch [regex]::Escape($requiredRef)) {
+        throw ("Provided PR_BODY env value is missing required roadmap reference line: {0}" -f $requiredRef)
+    }
+}
+
+Write-Host 'roadmap_guard OK.'

--- a/tools/guards/run_all_guards.ps1
+++ b/tools/guards/run_all_guards.ps1
@@ -1,12 +1,29 @@
-$ErrorActionPreference = "Stop"
+$ErrorActionPreference = 'Stop'
 
-$guardsPath = $PSScriptRoot
+$guards = @(
+    @{ Name = 'roadmap_guard.ps1'; Arguments = @('-Strict') },
+    @{ Name = 'commit_guard.ps1'; Arguments = @('-Strict') },
+    @{ Name = 'docs_guard.ps1'; Arguments = @() }
+)
 
-Write-Host 'Running roadmap guard...'
-& pwsh -File (Join-Path $guardsPath 'roadmap_guard.ps1') -Strict
+foreach ($guard in $guards) {
+    $scriptPath = Join-Path $PSScriptRoot $guard.Name
+    if (-not (Test-Path $scriptPath)) {
+        throw ("Guard script not found: {0}" -f $guard.Name)
+    }
 
-Write-Host 'Running commit guard...'
-& pwsh -File (Join-Path $guardsPath 'commit_guard.ps1') -Strict
+    Write-Host ("Running {0}..." -f $guard.Name)
 
-Write-Host 'Running docs guard...'
-& pwsh -File (Join-Path $guardsPath 'docs_guard.ps1')
+    $arguments = @()
+    if ($guard.Arguments) {
+        $arguments = $guard.Arguments
+    }
+
+    & $scriptPath @arguments
+
+    if ($LASTEXITCODE -ne 0) {
+        throw ("{0} failed with exit code {1}" -f $guard.Name, $LASTEXITCODE)
+    }
+}
+
+Write-Host 'All guards passed.'


### PR DESCRIPTION
## Summary
- update the PR template and guards workflow to require the step-02 roadmap reference and feed PR body text into the guard job
- expand the guard tooling with stricter roadmap validation plus a helper script and troubleshooting docs for injecting the reference
- align the step-02 roadmap doc with validation metadata expected by the strict guard run

## Testing
- ⚠️ `pwsh -NoLogo -File tools/guards/run_all_guards.ps1` *(fails: pwsh is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d18c4cf4e08330a07d56d3a09a8aaf