### PR TITLE
feat: add JWT authentication, admin seed, and RBAC guard

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -3,3 +3,6 @@ uvicorn==0.30.6
 httpx==0.27.2
 pytest==8.3.2
 pytest-cov==5.0.0
+SQLAlchemy==2.0.36
+passlib[bcrypt]==1.7.4
+python-jose==3.3.0

--- a/backend/src/app/__init__.py
+++ b/backend/src/app/__init__.py
@@ -1,0 +1,10 @@
+"""Codex backend application package."""
+
+from __future__ import annotations
+
+from importlib import import_module
+
+# Ensure ORM models are discoverable via `from src.app import models`.
+models = import_module("src.app.models")
+
+__all__ = ["models"]

--- a/backend/src/app/api/deps.py
+++ b/backend/src/app/api/deps.py
@@ -1,0 +1,59 @@
+"""Reusable FastAPI dependencies for authentication and RBAC."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from fastapi import Depends, HTTPException, status
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from sqlalchemy.orm import Session
+
+from src.app.db.session import get_session
+from src.app.models import User
+from src.app.services.auth import AuthError, auth_service
+from src.app.services.users import user_service
+
+_bearer_scheme = HTTPBearer(auto_error=False)
+
+
+def get_current_user(
+    credentials: HTTPAuthorizationCredentials | None = Depends(_bearer_scheme),
+    session: Session = Depends(get_session),
+) -> User:
+    """Return the authenticated user from the provided bearer token."""
+
+    if credentials is None:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Not authenticated")
+
+    token = credentials.credentials
+    try:
+        payload = auth_service.decode_token(token, expected_type="access")
+    except AuthError as exc:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token") from exc
+
+    subject = payload.get("sub")
+    if not subject:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token payload")
+
+    user = user_service.get_by_email(session, subject)
+    if user is None or not user.is_active:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Inactive or unknown user")
+
+    return user
+
+
+def require_roles(*roles: str) -> Callable[[User], User]:
+    """Dependency factory ensuring the current user owns one of the provided roles."""
+
+    required = {role.lower() for role in roles}
+
+    def _dependency(current_user: User = Depends(get_current_user)) -> User:
+        user_roles = {role.name.lower() for role in current_user.roles}
+        if required and required.isdisjoint(user_roles):
+            raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Missing required role")
+        return current_user
+
+    return _dependency
+
+
+__all__ = ["get_current_user", "require_roles"]

--- a/backend/src/app/api/v1/__init__.py
+++ b/backend/src/app/api/v1/__init__.py
@@ -1,0 +1,16 @@
+"""API routers for version 1."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter
+
+from .auth import router as auth_router
+from .health import router as health_router
+from .users import router as users_router
+
+api_router = APIRouter()
+api_router.include_router(health_router)
+api_router.include_router(auth_router)
+api_router.include_router(users_router)
+
+__all__ = ["api_router"]

--- a/backend/src/app/api/v1/auth.py
+++ b/backend/src/app/api/v1/auth.py
@@ -1,0 +1,67 @@
+"""Authentication API endpoints."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from src.app.api.deps import get_current_user
+from src.app.db.session import get_session
+from src.app.models import User
+from src.app.schemas.auth import LoginRequest, RefreshRequest, TokenPair
+from src.app.schemas.user import UserRead
+from src.app.services.auth import AuthError, auth_service
+from src.app.services.users import user_service
+
+router = APIRouter(prefix="/auth", tags=["auth"])
+
+
+@router.post("/login", response_model=TokenPair, summary="Authenticate a user with email and password")
+def login(payload: LoginRequest, session: Session = Depends(get_session)) -> TokenPair:
+    """Authenticate a user and return a token pair."""
+
+    user = user_service.get_by_email(session, payload.email)
+    if user is None:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid credentials")
+
+    roles = user_service.list_role_names(user)
+    if not roles:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="User has no roles")
+
+    if not auth_service.verify_password(payload.password, user.hashed_password):
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid credentials")
+
+    token_pair = auth_service.create_token_pair(user.email, roles)
+    return TokenPair(**token_pair)
+
+
+@router.post("/refresh", response_model=TokenPair, summary="Refresh an access token")
+def refresh(payload: RefreshRequest, session: Session = Depends(get_session)) -> TokenPair:
+    """Refresh the access token using a refresh token."""
+
+    try:
+        token_payload = auth_service.decode_token(payload.refresh_token, expected_type="refresh")
+    except AuthError as exc:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid refresh token") from exc
+
+    subject = token_payload.get("sub")
+    if subject is None:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid refresh token")
+
+    user = user_service.get_by_email(session, subject)
+    if user is None or not user.is_active:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Inactive or unknown user")
+
+    roles = user_service.list_role_names(user)
+    token_pair = auth_service.create_token_pair(user.email, roles)
+    return TokenPair(**token_pair)
+
+
+@router.get("/me", response_model=UserRead, summary="Return the current authenticated user")
+def read_profile(current_user: User = Depends(get_current_user)) -> UserRead:
+    """Return details for the currently authenticated user."""
+
+    return UserRead.model_validate(current_user)
+
+
+__all__ = ["router"]

--- a/backend/src/app/api/v1/users.py
+++ b/backend/src/app/api/v1/users.py
@@ -1,0 +1,33 @@
+"""User API endpoints with RBAC enforcement."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+
+from src.app.api.deps import get_current_user, require_roles
+from src.app.models import User
+from src.app.schemas.user import UserRead
+
+router = APIRouter(prefix="/users", tags=["users"])
+
+
+@router.get("/me", response_model=UserRead, summary="Return the currently authenticated user")
+def read_current_user(current_user: User = Depends(get_current_user)) -> UserRead:
+    """Return details of the logged-in user."""
+
+    return UserRead.model_validate(current_user)
+
+
+@router.get(
+    "/admin/pulse",
+    response_model=dict[str, str],
+    summary="Admin-only heartbeat endpoint",
+    dependencies=[Depends(require_roles("admin"))],
+)
+def admin_pulse() -> dict[str, str]:
+    """Demonstrate RBAC by requiring the admin role."""
+
+    return {"status": "admin-ok"}
+
+
+__all__ = ["router"]

--- a/backend/src/app/core/__init__.py
+++ b/backend/src/app/core/__init__.py
@@ -1,0 +1,5 @@
+"""Core configuration utilities for the Codex backend."""
+
+from .config import settings
+
+__all__ = ["settings"]

--- a/backend/src/app/core/config.py
+++ b/backend/src/app/core/config.py
@@ -1,0 +1,45 @@
+"""Application configuration primitives."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import os
+
+
+@dataclass(slots=True)
+class Settings:
+    """Runtime configuration resolved from environment variables."""
+
+    app_name: str = "Codex API"
+    app_version: str = "0.1.0"
+    database_url: str = "sqlite:///./codex.db"
+    jwt_secret: str = "change_me"
+    jwt_algorithm: str = "HS256"
+    access_token_expire_minutes: int = 15
+    refresh_token_expire_minutes: int = 60
+
+    @classmethod
+    def from_env(cls) -> "Settings":
+        """Build a :class:`Settings` instance using environment variables."""
+
+        defaults = cls()
+        database_url = os.getenv("DATABASE_URL") or defaults.database_url
+        jwt_secret = os.getenv("JWT_SECRET") or defaults.jwt_secret
+        jwt_algorithm = os.getenv("JWT_ALGORITHM") or defaults.jwt_algorithm
+        access_expire = int(os.getenv("JWT_ACCESS_EXPIRE_MINUTES", defaults.access_token_expire_minutes))
+        refresh_expire = int(os.getenv("JWT_REFRESH_EXPIRE_MINUTES", defaults.refresh_token_expire_minutes))
+        return cls(
+            app_name=os.getenv("APP_NAME", defaults.app_name),
+            app_version=os.getenv("APP_VERSION", defaults.app_version),
+            database_url=database_url,
+            jwt_secret=jwt_secret,
+            jwt_algorithm=jwt_algorithm,
+            access_token_expire_minutes=access_expire,
+            refresh_token_expire_minutes=refresh_expire,
+        )
+
+
+settings = Settings.from_env()
+
+
+__all__ = ["Settings", "settings"]

--- a/backend/src/app/db/base.py
+++ b/backend/src/app/db/base.py
@@ -1,0 +1,10 @@
+"""SQLAlchemy declarative base for the Codex backend."""
+
+from sqlalchemy.orm import DeclarativeBase
+
+
+class Base(DeclarativeBase):
+    """Base class for all ORM models."""
+
+
+__all__ = ["Base"]

--- a/backend/src/app/db/session.py
+++ b/backend/src/app/db/session.py
@@ -1,0 +1,30 @@
+"""Database session handling utilities."""
+
+from __future__ import annotations
+
+from collections.abc import Generator
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+
+from src.app.core.config import settings
+
+_connect_args: dict[str, object] = {}
+if settings.database_url.startswith("sqlite"):  # pragma: no cover - branch ensures sqlite compatibility
+    _connect_args["check_same_thread"] = False
+
+engine = create_engine(settings.database_url, connect_args=_connect_args)
+SessionLocal = sessionmaker(bind=engine, autocommit=False, autoflush=False, expire_on_commit=False)
+
+
+def get_session() -> Generator[Session, None, None]:
+    """Yield a database session for FastAPI dependencies."""
+
+    session = SessionLocal()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+__all__ = ["SessionLocal", "engine", "get_session"]

--- a/backend/src/app/db/utils.py
+++ b/backend/src/app/db/utils.py
@@ -1,0 +1,18 @@
+"""Helpers for database lifecycle management."""
+
+from __future__ import annotations
+
+from src.app.db.base import Base
+from src.app.db.session import engine
+
+
+def create_all_tables() -> None:
+    """Create all database tables registered on the declarative base."""
+
+    # Import models to ensure their metadata is registered before creating tables.
+    from src.app import models  # noqa: F401
+
+    Base.metadata.create_all(bind=engine)
+
+
+__all__ = ["create_all_tables"]

--- a/backend/src/app/main.py
+++ b/backend/src/app/main.py
@@ -1,10 +1,29 @@
+"""Main FastAPI application instance."""
+
+from __future__ import annotations
+
 from fastapi import FastAPI
 
-from .api.v1.health import router as health_router
+from src.app.api.v1 import api_router
+from src.app.core import settings
+from src.app.db.session import SessionLocal
+from src.app.db.utils import create_all_tables
+from src.app.services.users import user_service
+
+app = FastAPI(title=settings.app_name, version=settings.app_version)
+app.include_router(api_router, prefix="/api/v1")
 
 
-app = FastAPI(title="Codex API", version="0.1.0")
-app.include_router(health_router, prefix="/api/v1")
+@app.on_event("startup")
+def _on_startup() -> None:
+    """Initialise database tables and default roles on application startup."""
+
+    create_all_tables()
+    session = SessionLocal()
+    try:
+        user_service.ensure_default_roles(session)
+    finally:
+        session.close()
 
 
 __all__ = ["app"]

--- a/backend/src/app/models/__init__.py
+++ b/backend/src/app/models/__init__.py
@@ -1,0 +1,7 @@
+"""ORM models exposed by the Codex backend."""
+
+from .permission import Permission
+from .role import Role
+from .user import User
+
+__all__ = ["Permission", "Role", "User"]

--- a/backend/src/app/models/permission.py
+++ b/backend/src/app/models/permission.py
@@ -1,0 +1,26 @@
+"""Permission model definition."""
+
+from __future__ import annotations
+
+from sqlalchemy import Integer, String
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from src.app.db.base import Base
+
+
+class Permission(Base):
+    """Represents a granular permission assigned to roles."""
+
+    __tablename__ = "permissions"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    name: Mapped[str] = mapped_column(String(100), unique=True, index=True)
+    description: Mapped[str | None] = mapped_column(String(255), nullable=True)
+
+    roles = relationship("Role", secondary="role_permissions", back_populates="permissions")
+
+    def __repr__(self) -> str:  # pragma: no cover - repr helpers used for debugging
+        return f"Permission(id={self.id!r}, name={self.name!r})"
+
+
+__all__ = ["Permission"]

--- a/backend/src/app/models/role.py
+++ b/backend/src/app/models/role.py
@@ -1,0 +1,34 @@
+"""Role model definition."""
+
+from __future__ import annotations
+
+from sqlalchemy import Column, ForeignKey, Integer, String, Table
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from src.app.db.base import Base
+
+role_permissions = Table(
+    "role_permissions",
+    Base.metadata,
+    Column("role_id", ForeignKey("roles.id", ondelete="CASCADE"), primary_key=True),
+    Column("permission_id", ForeignKey("permissions.id", ondelete="CASCADE"), primary_key=True),
+)
+
+
+class Role(Base):
+    """Represents a RBAC role with associated permissions."""
+
+    __tablename__ = "roles"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    name: Mapped[str] = mapped_column(String(50), unique=True, index=True)
+    description: Mapped[str | None] = mapped_column(String(255), nullable=True)
+
+    permissions = relationship("Permission", secondary=role_permissions, back_populates="roles")
+    users = relationship("User", secondary="user_roles", back_populates="roles")
+
+    def __repr__(self) -> str:  # pragma: no cover - repr helpers used for debugging
+        return f"Role(id={self.id!r}, name={self.name!r})"
+
+
+__all__ = ["Role", "role_permissions"]

--- a/backend/src/app/models/user.py
+++ b/backend/src/app/models/user.py
@@ -1,0 +1,34 @@
+"""User model definition."""
+
+from __future__ import annotations
+
+from sqlalchemy import Boolean, Column, ForeignKey, Integer, String, Table
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from src.app.db.base import Base
+
+user_roles = Table(
+    "user_roles",
+    Base.metadata,
+    Column("user_id", ForeignKey("users.id", ondelete="CASCADE"), primary_key=True),
+    Column("role_id", ForeignKey("roles.id", ondelete="CASCADE"), primary_key=True),
+)
+
+
+class User(Base):
+    """Represents an authenticated platform user."""
+
+    __tablename__ = "users"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    email: Mapped[str] = mapped_column(String(255), unique=True, index=True)
+    hashed_password: Mapped[str] = mapped_column(String(255))
+    is_active: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
+
+    roles = relationship("Role", secondary=user_roles, back_populates="users")
+
+    def __repr__(self) -> str:  # pragma: no cover - repr helpers used for debugging
+        return f"User(id={self.id!r}, email={self.email!r})"
+
+
+__all__ = ["User", "user_roles"]

--- a/backend/src/app/schemas/__init__.py
+++ b/backend/src/app/schemas/__init__.py
@@ -1,0 +1,12 @@
+"""Expose pydantic schemas."""
+
+from .auth import LoginRequest, RefreshRequest, TokenPair
+from .user import RoleRead, UserRead
+
+__all__ = [
+    "LoginRequest",
+    "RefreshRequest",
+    "RoleRead",
+    "TokenPair",
+    "UserRead",
+]

--- a/backend/src/app/schemas/auth.py
+++ b/backend/src/app/schemas/auth.py
@@ -1,0 +1,31 @@
+"""Pydantic schemas for authentication payloads."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class LoginRequest(BaseModel):
+    """Request body for the login endpoint."""
+
+    email: str = Field(..., examples=["admin@example.com"])
+    password: str = Field(..., min_length=1)
+
+
+class RefreshRequest(BaseModel):
+    """Request body for refreshing an access token."""
+
+    refresh_token: str = Field(..., min_length=10)
+
+
+class TokenPair(BaseModel):
+    """Response returned after a successful authentication or refresh."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    access_token: str
+    refresh_token: str
+    token_type: str = "bearer"
+
+
+__all__ = ["LoginRequest", "RefreshRequest", "TokenPair"]

--- a/backend/src/app/schemas/user.py
+++ b/backend/src/app/schemas/user.py
@@ -1,0 +1,27 @@
+"""Pydantic schemas for user responses."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class RoleRead(BaseModel):
+    """Public representation of a role."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    name: str
+
+
+class UserRead(BaseModel):
+    """Public representation of a user."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    email: str
+    is_active: bool
+    roles: list[RoleRead] = Field(default_factory=list)
+
+
+__all__ = ["RoleRead", "UserRead"]

--- a/backend/src/app/scripts/seed.py
+++ b/backend/src/app/scripts/seed.py
@@ -1,0 +1,33 @@
+"""Seed script for creating a default admin user."""
+
+from __future__ import annotations
+
+from src.app.core import settings
+from src.app.db.session import SessionLocal
+from src.app.db.utils import create_all_tables
+from src.app.services.users import user_service
+
+ADMIN_EMAIL = "admin@example.com"
+ADMIN_PASSWORD = "admin"
+
+
+def main() -> None:
+    """Seed the database with an admin user if none exists."""
+
+    create_all_tables()
+    session = SessionLocal()
+    try:
+        user_service.ensure_default_roles(session)
+        existing = user_service.get_by_email(session, ADMIN_EMAIL)
+        if existing is None:
+            user_service.create_user(session, ADMIN_EMAIL, ADMIN_PASSWORD, roles=["admin"])
+            print(f"Admin user created: {ADMIN_EMAIL}")  # noqa: T201 - script feedback
+        else:
+            print("Admin user already exists")  # noqa: T201 - script feedback
+    finally:
+        session.close()
+
+
+if __name__ == "__main__":
+    print(f"Using database: {settings.database_url}")  # noqa: T201 - script feedback
+    main()

--- a/backend/src/app/services/__init__.py
+++ b/backend/src/app/services/__init__.py
@@ -1,0 +1,12 @@
+"""Service layer exports."""
+
+from .auth import AuthService, AuthError, auth_service
+from .users import UserService, user_service
+
+__all__ = [
+    "AuthError",
+    "AuthService",
+    "UserService",
+    "auth_service",
+    "user_service",
+]

--- a/backend/src/app/services/auth.py
+++ b/backend/src/app/services/auth.py
@@ -1,0 +1,92 @@
+"""Authentication helpers for hashing and token management."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Any
+from uuid import uuid4
+
+from jose import JWTError, jwt
+from passlib.context import CryptContext
+
+from src.app.core.config import settings
+
+
+class AuthError(RuntimeError):
+    """Raised when an authentication operation fails."""
+
+
+class AuthService:
+    """Provide password hashing and JWT helpers."""
+
+    def __init__(self) -> None:
+        self._pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+
+    def hash_password(self, password: str) -> str:
+        """Return a bcrypt hash for the provided password."""
+
+        return self._pwd_context.hash(password)
+
+    def verify_password(self, plain_password: str, hashed_password: str) -> bool:
+        """Verify that the provided password matches the stored hash."""
+
+        return self._pwd_context.verify(plain_password, hashed_password)
+
+    def _create_token(
+        self,
+        subject: str,
+        token_type: str,
+        expires_delta: timedelta,
+        payload: dict[str, Any] | None = None,
+    ) -> str:
+        issued_at = datetime.now(tz=timezone.utc)
+        expire = issued_at + expires_delta
+        to_encode: dict[str, Any] = {
+            "sub": subject,
+            "type": token_type,
+            "exp": expire,
+            "iat": issued_at,
+            "jti": uuid4().hex,
+        }
+        if payload:
+            to_encode.update(payload)
+        return jwt.encode(to_encode, settings.jwt_secret, algorithm=settings.jwt_algorithm)
+
+    def create_access_token(self, subject: str, roles: list[str]) -> str:
+        """Generate an access token embedding the user roles."""
+
+        expires = timedelta(minutes=settings.access_token_expire_minutes)
+        return self._create_token(subject, "access", expires, {"roles": roles})
+
+    def create_refresh_token(self, subject: str) -> str:
+        """Generate a refresh token for the provided subject."""
+
+        expires = timedelta(minutes=settings.refresh_token_expire_minutes)
+        return self._create_token(subject, "refresh", expires)
+
+    def decode_token(self, token: str, expected_type: str | None = None) -> dict[str, Any]:
+        """Decode a JWT token and optionally validate its type."""
+
+        try:
+            payload = jwt.decode(token, settings.jwt_secret, algorithms=[settings.jwt_algorithm])
+        except JWTError as exc:  # pragma: no cover - jose raises multiple subclasses we treat the same way
+            raise AuthError("Invalid token") from exc
+
+        token_type = payload.get("type")
+        if expected_type and token_type != expected_type:
+            raise AuthError("Invalid token type")
+
+        return payload
+
+    def create_token_pair(self, subject: str, roles: list[str]) -> dict[str, str]:
+        """Return a pair of access and refresh tokens."""
+
+        access = self.create_access_token(subject, roles)
+        refresh = self.create_refresh_token(subject)
+        return {"access_token": access, "refresh_token": refresh, "token_type": "bearer"}
+
+
+auth_service = AuthService()
+
+
+__all__ = ["AuthError", "AuthService", "auth_service"]

--- a/backend/src/app/services/users.py
+++ b/backend/src/app/services/users.py
@@ -1,0 +1,112 @@
+"""Service helpers for user and RBAC management."""
+
+from __future__ import annotations
+
+from typing import Iterable, Sequence
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from src.app.models import Permission, Role, User
+from src.app.models.role import role_permissions
+from src.app.models.user import user_roles
+from src.app.services.auth import auth_service
+
+_ROLE_PRESETS: dict[str, dict[str, Sequence[str]]] = {
+    "admin": {"permissions": ("auth:login", "auth:refresh", "users:manage")},
+    "manager": {"permissions": ("auth:login", "missions:manage")},
+    "tech": {"permissions": ("auth:login", "missions:execute")},
+    "viewer": {"permissions": ("auth:login", "missions:view")},
+}
+
+_PERMISSION_DESCRIPTIONS: dict[str, str] = {
+    "auth:login": "Allow authentication via email/password.",
+    "auth:refresh": "Allow refreshing access tokens.",
+    "users:manage": "Manage user accounts and roles.",
+    "missions:manage": "Manage missions and planning data.",
+    "missions:execute": "Execute missions assigned to the technician.",
+    "missions:view": "View missions and planning information.",
+}
+
+
+class UserService:
+    """Encapsulate business logic for user and role management."""
+
+    def ensure_default_roles(self, session: Session) -> None:
+        """Ensure the minimal set of roles and permissions exists."""
+
+        for perm_name, description in _PERMISSION_DESCRIPTIONS.items():
+            existing = session.execute(select(Permission).where(Permission.name == perm_name)).scalar_one_or_none()
+            if existing is None:
+                session.add(Permission(name=perm_name, description=description))
+
+        session.flush()
+
+        for role_name, preset in _ROLE_PRESETS.items():
+            role = session.execute(select(Role).where(Role.name == role_name)).scalar_one_or_none()
+            if role is None:
+                role = Role(name=role_name)
+                session.add(role)
+                session.flush([role])
+
+            permissions = list(self._get_permissions(session, preset.get("permissions", ())))
+            role.permissions = permissions
+
+        session.commit()
+
+    def create_user(self, session: Session, email: str, password: str, roles: Iterable[str] | None = None) -> User:
+        """Create a new user with the provided credentials."""
+
+        hashed = auth_service.hash_password(password)
+        user = User(email=email, hashed_password=hashed)
+        session.add(user)
+        session.flush([user])
+
+        if roles:
+            attached_roles = [self._get_or_create_role(session, role_name) for role_name in roles]
+            user.roles = attached_roles
+
+        session.commit()
+        session.refresh(user)
+        return user
+
+    def get_by_email(self, session: Session, email: str) -> User | None:
+        """Return a user by email."""
+
+        return session.execute(select(User).where(User.email == email)).scalar_one_or_none()
+
+    def _get_permissions(self, session: Session, names: Iterable[str]) -> Iterable[Permission]:
+        for name in names:
+            permission = session.execute(select(Permission).where(Permission.name == name)).scalar_one_or_none()
+            if permission is None:
+                permission = Permission(name=name, description=_PERMISSION_DESCRIPTIONS.get(name))
+                session.add(permission)
+                session.flush([permission])
+            yield permission
+
+    def _get_or_create_role(self, session: Session, name: str) -> Role:
+        role = session.execute(select(Role).where(Role.name == name)).scalar_one_or_none()
+        if role is None:
+            role = Role(name=name)
+            session.add(role)
+            session.flush([role])
+        return role
+
+    def list_role_names(self, user: User) -> list[str]:
+        """Return the list of role names for the provided user."""
+
+        return [role.name for role in user.roles]
+
+
+def detach_user_relationships(session: Session) -> None:
+    """Helper to clear association tables (useful for tests)."""
+
+    session.execute(user_roles.delete())
+    session.execute(role_permissions.delete())
+    session.commit()
+
+
+user_service = UserService()
+
+
+__all__ = ["UserService", "user_service", "detach_user_relationships"]

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,74 @@
+"""Test fixtures for backend authentication tests."""
+
+from __future__ import annotations
+
+from collections.abc import Generator
+from pathlib import Path
+import sys
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.pool import StaticPool
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+SRC_PATH = ROOT_DIR / "src"
+for candidate in (ROOT_DIR, SRC_PATH):
+    if str(candidate) not in sys.path:
+        sys.path.insert(0, str(candidate))
+
+from src.app.db.base import Base  # noqa: E402
+from src.app.db.session import get_session  # noqa: E402
+from src.app.main import app  # noqa: E402
+from src.app.services.users import user_service  # noqa: E402
+
+TEST_DATABASE_URL = "sqlite:///:memory:"
+
+
+def _create_engine():
+    connect_args = {"check_same_thread": False} if TEST_DATABASE_URL.startswith("sqlite") else {}
+    pool_kwargs = {"poolclass": StaticPool} if TEST_DATABASE_URL.startswith("sqlite") else {}
+    return create_engine(TEST_DATABASE_URL, connect_args=connect_args, **pool_kwargs)
+
+
+@pytest.fixture(scope="session")
+def engine() -> Generator:
+    engine = _create_engine()
+    Base.metadata.create_all(bind=engine)
+    yield engine
+    Base.metadata.drop_all(bind=engine)
+
+
+@pytest.fixture()
+def db_session(engine) -> Generator[Session, None, None]:
+    Base.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+    TestingSessionLocal = sessionmaker(bind=engine, autocommit=False, autoflush=False)
+    session = TestingSessionLocal()
+    user_service.ensure_default_roles(session)
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+@pytest.fixture()
+def client(db_session: Session) -> Generator[TestClient, None, None]:
+    def _override_get_session() -> Generator[Session, None, None]:
+        try:
+            yield db_session
+        finally:
+            db_session.rollback()
+
+    app.dependency_overrides[get_session] = _override_get_session
+    with TestClient(app) as test_client:
+        yield test_client
+    app.dependency_overrides.pop(get_session, None)
+
+
+@pytest.fixture()
+def create_user(db_session: Session):
+    def _create(email: str, password: str, roles: list[str]) -> None:
+        user_service.create_user(db_session, email, password, roles=roles)
+    return _create

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -1,0 +1,98 @@
+"""Integration tests for authentication endpoints and RBAC."""
+
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from src.app.services.auth import auth_service
+
+
+def test_login_returns_token_pair(client: TestClient, create_user) -> None:
+    email = "admin@example.com"
+    password = "super-secret"
+    create_user(email, password, roles=["admin"])
+
+    response = client.post(
+        "/api/v1/auth/login",
+        json={"email": email, "password": password},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["token_type"] == "bearer"
+    assert "access_token" in data and "refresh_token" in data
+
+
+def test_login_rejects_invalid_password(client: TestClient, create_user) -> None:
+    email = "admin2@example.com"
+    create_user(email, "correct-password", roles=["admin"])
+
+    response = client.post(
+        "/api/v1/auth/login",
+        json={"email": email, "password": "wrong"},
+    )
+
+    assert response.status_code == 401
+
+
+def test_refresh_issues_new_tokens(client: TestClient, create_user) -> None:
+    email = "viewer@example.com"
+    password = "viewer-pass"
+    create_user(email, password, roles=["viewer"])
+
+    login_response = client.post(
+        "/api/v1/auth/login",
+        json={"email": email, "password": password},
+    )
+    refresh_token = login_response.json()["refresh_token"]
+
+    refresh_response = client.post(
+        "/api/v1/auth/refresh",
+        json={"refresh_token": refresh_token},
+    )
+
+    assert refresh_response.status_code == 200
+    data = refresh_response.json()
+    assert data["access_token"] != login_response.json()["access_token"]
+    assert data["refresh_token"]
+
+
+def test_admin_route_requires_admin_role(client: TestClient, create_user) -> None:
+    email = "manager@example.com"
+    password = "manager-pass"
+    create_user(email, password, roles=["manager"])
+
+    login_response = client.post(
+        "/api/v1/auth/login",
+        json={"email": email, "password": password},
+    )
+    token = login_response.json()["access_token"]
+
+    response = client.get(
+        "/api/v1/users/admin/pulse",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert response.status_code == 403
+
+    # Create an admin and ensure access works.
+    admin_email = "admin-role@example.com"
+    admin_password = "admin-pass"
+    create_user(admin_email, admin_password, roles=["admin"])
+    admin_login = client.post(
+        "/api/v1/auth/login",
+        json={"email": admin_email, "password": admin_password},
+    )
+    admin_token = admin_login.json()["access_token"]
+    admin_response = client.get(
+        "/api/v1/users/admin/pulse",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert admin_response.status_code == 200
+    assert admin_response.json()["status"] == "admin-ok"
+
+
+def test_hashing_helpers_roundtrip() -> None:
+    password = "roundtrip"
+    hashed = auth_service.hash_password(password)
+    assert auth_service.verify_password(password, hashed)

--- a/backend/tests/test_health.py
+++ b/backend/tests/test_health.py
@@ -1,6 +1,10 @@
+"""Smoke tests for the health endpoint."""
+
+from __future__ import annotations
+
 from fastapi.testclient import TestClient
 
-from app.main import app
+from src.app.main import app
 
 
 def test_health_endpoint_returns_ok_status() -> None:

--- a/docs/roadmap/step-03.md
+++ b/docs/roadmap/step-03.md
@@ -1,0 +1,86 @@
+# docs/roadmap/step-03.md — Auth JWT + Seed Admin + RBAC minimal
+
+> Objectif: fournir une authentification JWT (login + refresh), initialiser un utilisateur admin seedé via script, et activer un RBAC minimal (roles + permissions) accessible depuis les APIs et le frontend.
+
+Ref: docs/roadmap/step-03.md
+
+---
+
+## 1) Contexte & objectifs
+- Exposer des endpoints `/api/v1/auth/login` et `/api/v1/auth/refresh` avec FastAPI.
+- Gérer le hash et la vérification des mots de passe via bcrypt.
+- Générer des tokens JWT HS256 (access + refresh) contenant les rôles.
+- Enregistrer les modèles `User`, `Role`, `Permission` + tables associatives.
+- Seed automatique des rôles (admin, manager, tech, viewer) au démarrage + script `seed.py` pour l’utilisateur admin.
+- Exemple d’endpoint protégé (`GET /api/v1/users/admin/pulse`) utilisant RBAC.
+- Frontend: page de login, store Zustand pour les tokens, ProtectedRoute.
+- Couverture tests backend/frontend >= 70 %.
+
+---
+
+## 2) Périmètre livré
+- **Backend**: configuration runtime (`Settings`), moteur SQLAlchemy + sessions, services auth/users, API login/refresh/me, RBAC admin, script seed.
+- **Frontend**: router protégé, page de login, hook `useAuth`, store Zustand, tests RTL.
+- **DevOps**: script PowerShell `tools/dev/seed.ps1` exécutant le seed Python.
+- **Docs**: ce fichier roadmap documente la livraison.
+
+Hors périmètre: gestion utilisateurs avancée, stockage persistant des tokens, UI dashboard complète.
+
+---
+
+## 3) Backend — détails techniques
+- `src/app/core/config.py` charge les variables env (JWT secret, durée, URL DB).
+- `src/app/db/` fournit base déclarative, session SQLAlchemy, helper `create_all_tables`.
+- Modèles ORM: `User`, `Role`, `Permission` + tables `user_roles`, `role_permissions`.
+- Service `AuthService` (hash bcrypt, création/validation tokens HS256).
+- Service `UserService` (création utilisateur, ensure roles/permissions par défaut, listing roles).
+- Routers FastAPI:
+  - `/auth/login` : vérifie email/password, renvoie `TokenPair` (access + refresh + type).
+  - `/auth/refresh` : vérifie refresh token, renvoie un nouveau couple access/refresh.
+  - `/auth/me` : renvoie l’utilisateur courant.
+  - `/users/me` & `/users/admin/pulse` : RBAC (admin requis pour pulse).
+- Dépendances `get_current_user` + `require_roles` (HTTP Bearer + validation roles).
+- Startup: création tables + seed des rôles par défaut.
+- Seed Python (`backend/src/app/scripts/seed.py`) crée `admin@example.com` (mdp `admin`).
+
+---
+
+## 4) Frontend — détails techniques
+- `App.tsx` utilise React Router (`/login`, `/` protégé) et `ProtectedRoute`.
+- `LoginPage` (formulaire contrôlé, état d’erreur, bouton disabled pendant submit).
+- Hook `useAuth` (fetch login/refresh, stockage tokens mémoire via Zustand).
+- Store `useAuthStore` centralise `accessToken`/`refreshToken`.
+- Tests RTL/Vitest: redirection login par défaut, soumission du formulaire (mock fetch), gestion erreur.
+
+---
+
+## 5) Tests & CI
+- Backend: `pytest` avec fixtures SQLite in-memory (StaticPool), tests login/refresh/RBAC/hash.
+- Frontend: `vitest run --coverage` avec mocks fetch + `@testing-library/user-event`.
+- Couverture consolidée > 70 % (backend + frontend).
+
+---
+
+## 6) Scripts & opérations
+- `tools/dev/seed.ps1`: lance `python backend/src/app/scripts/seed.py` (affiche base utilisée, crée admin si absent).
+- Utilisation: `pwsh ./tools/dev/seed.ps1` après migrations pour disposer d’un admin prêt à l’emploi.
+
+---
+
+## 7) Validation & next steps
+- Endpoints login/refresh opérationnels (tests automatisés).
+- RBAC admin opérationnel (`/api/v1/users/admin/pulse`).
+- Admin seedé (PowerShell + script Python).
+- Frontend protège l’accès au dashboard (redirect login).
+
+Prochaines étapes (step-04): missions CRUD + liaisons utilisateurs.
+
+---
+
+## 8) Journal de validation
+```
+ETAPE 03: Auth JWT + Seed Admin + RBAC minimal
+CI: backend-tests = ok, frontend-tests = ok, guards = ok
+Couverture backend: >70 %, frontend: >70 %
+VALIDATE? yes/no
+```

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,7 +13,9 @@
   },
   "dependencies": {
     "react": "^19.1.1",
-    "react-dom": "^19.1.1"
+    "react-dom": "^19.1.1",
+    "react-router-dom": "^7.9.1",
+    "zustand": "^5.0.8"
   },
   "devDependencies": {
     "@eslint/js": "^9.36.0",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -14,6 +14,12 @@ importers:
       react-dom:
         specifier: ^19.1.1
         version: 19.1.1(react@19.1.1)
+      react-router-dom:
+        specifier: ^7.9.1
+        version: 7.9.1(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      zustand:
+        specifier: ^5.0.8
+        version: 5.0.8(@types/react@19.1.13)(react@19.1.1)
     devDependencies:
       '@eslint/js':
         specifier: ^9.36.0
@@ -898,6 +904,10 @@ packages:
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
+  cookie@1.0.2:
+    resolution: {integrity: sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==}
+    engines: {node: '>=18'}
+
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
@@ -1510,6 +1520,23 @@ packages:
     resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
     engines: {node: '>=0.10.0'}
 
+  react-router-dom@7.9.1:
+    resolution: {integrity: sha512-U9WBQssBE9B1vmRjo9qTM7YRzfZ3lUxESIZnsf4VjR/lXYz9MHjvOxHzr/aUm4efpktbVOrF09rL/y4VHa8RMw==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: '>=18'
+      react-dom: '>=18'
+
+  react-router@7.9.1:
+    resolution: {integrity: sha512-pfAByjcTpX55mqSDGwGnY9vDCpxqBLASg0BMNAuMmpSGESo/TaOUG6BllhAtAkCGx8Rnohik/XtaqiYUJtgW2g==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: '>=18'
+      react-dom: '>=18'
+    peerDependenciesMeta:
+      react-dom:
+        optional: true
+
   react@19.1.1:
     resolution: {integrity: sha512-w8nqGImo45dmMIfljjMwOGtbmC/mk4CMYhWIicdSflH91J9TyCyczcPFXJzrZ/ZXcgGRFeP6BU0BEJTw6tZdfQ==}
     engines: {node: '>=0.10.0'}
@@ -1567,6 +1594,9 @@ packages:
     resolution: {integrity: sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==}
     engines: {node: '>=10'}
     hasBin: true
+
+  set-cookie-parser@2.7.1:
+    resolution: {integrity: sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==}
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -1878,6 +1908,24 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  zustand@5.0.8:
+    resolution: {integrity: sha512-gyPKpIaxY9XcO2vSMrLbiER7QMAMGOQZVRdJ6Zi782jkbzZygq5GI9nG8g+sMgitRtndwaBSl7uiqC49o1SSiw==}
+    engines: {node: '>=12.20.0'}
+    peerDependencies:
+      '@types/react': '>=18.0.0'
+      immer: '>=9.0.6'
+      react: '>=18.0.0'
+      use-sync-external-store: '>=1.2.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
+      use-sync-external-store:
+        optional: true
 
 snapshots:
 
@@ -2669,6 +2717,8 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
+  cookie@1.0.2: {}
+
   cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
@@ -3259,6 +3309,20 @@ snapshots:
 
   react-refresh@0.17.0: {}
 
+  react-router-dom@7.9.1(react-dom@19.1.1(react@19.1.1))(react@19.1.1):
+    dependencies:
+      react: 19.1.1
+      react-dom: 19.1.1(react@19.1.1)
+      react-router: 7.9.1(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+
+  react-router@7.9.1(react-dom@19.1.1(react@19.1.1))(react@19.1.1):
+    dependencies:
+      cookie: 1.0.2
+      react: 19.1.1
+      set-cookie-parser: 2.7.1
+    optionalDependencies:
+      react-dom: 19.1.1(react@19.1.1)
+
   react@19.1.1: {}
 
   read-cache@1.0.0:
@@ -3329,6 +3393,8 @@ snapshots:
   semver@6.3.1: {}
 
   semver@7.7.2: {}
+
+  set-cookie-parser@2.7.1: {}
 
   shebang-command@2.0.0:
     dependencies:
@@ -3633,3 +3699,8 @@ snapshots:
   yaml@2.8.1: {}
 
   yocto-queue@0.1.0: {}
+
+  zustand@5.0.8(@types/react@19.1.13)(react@19.1.1):
+    optionalDependencies:
+      '@types/react': 19.1.13
+      react: 19.1.1

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,14 +1,32 @@
-function App() {
+import { BrowserRouter, Route, Routes } from 'react-router-dom';
+
+import { ProtectedRoute } from './features/auth/components/ProtectedRoute';
+import { LoginPage } from './features/auth/pages/LoginPage';
+
+function Dashboard() {
   return (
-    <main className="flex flex-col items-center justify-center gap-4 px-4 py-12 text-center">
+    <main className="flex min-h-screen flex-col items-center justify-center gap-4 bg-slate-950 px-4 py-12 text-center text-slate-100">
       <span className="rounded-full bg-sky-500/10 px-4 py-1 text-sm font-semibold uppercase tracking-wide text-sky-300">
         Codex
       </span>
-      <h1 className="text-4xl font-bold text-slate-100 sm:text-5xl">Monorepo scaffold ready</h1>
+      <h1 className="text-4xl font-bold sm:text-5xl">Tableau de bord protégé</h1>
       <p className="max-w-xl text-base text-slate-300 sm:text-lg">
-        Backend, frontend and guards are configured. Run the automated tests to keep the health of the project in check.
+        Vous êtes authentifié. Ce tableau de bord est accessible uniquement après connexion.
       </p>
     </main>
+  );
+}
+
+function App() {
+  return (
+    <BrowserRouter>
+      <Routes>
+        <Route path="/login" element={<LoginPage />} />
+        <Route element={<ProtectedRoute />}>
+          <Route path="/" element={<Dashboard />} />
+        </Route>
+      </Routes>
+    </BrowserRouter>
   );
 }
 

--- a/frontend/src/__tests__/app.spec.tsx
+++ b/frontend/src/__tests__/app.spec.tsx
@@ -2,13 +2,11 @@ import { render, screen } from '@testing-library/react';
 
 import App from '../App';
 
-describe('App', () => {
-  it('renders the scaffold message', () => {
+describe('App routing', () => {
+  it('renders the login page when not authenticated', () => {
     render(<App />);
 
-    expect(screen.getByText(/monorepo scaffold ready/i)).toBeVisible();
-    expect(
-      screen.getByText(/Backend, frontend and guards are configured/i),
-    ).toBeVisible();
+    expect(screen.getByRole('heading', { name: /connexion/i })).toBeVisible();
+    expect(screen.getByRole('button', { name: /se connecter/i })).toBeEnabled();
   });
 });

--- a/frontend/src/features/auth/components/ProtectedRoute.tsx
+++ b/frontend/src/features/auth/components/ProtectedRoute.tsx
@@ -1,0 +1,14 @@
+import { Navigate, Outlet, useLocation } from 'react-router-dom';
+
+import { useAuth } from '../hooks/useAuth';
+
+export function ProtectedRoute() {
+  const { isAuthenticated } = useAuth();
+  const location = useLocation();
+
+  if (!isAuthenticated) {
+    return <Navigate to="/login" replace state={{ from: location }} />;
+  }
+
+  return <Outlet />;
+}

--- a/frontend/src/features/auth/hooks/useAuth.ts
+++ b/frontend/src/features/auth/hooks/useAuth.ts
@@ -1,0 +1,68 @@
+import { useCallback, useMemo } from 'react';
+
+import { useAuthStore } from '../store/auth';
+
+const API_URL = import.meta.env.VITE_API_URL ?? 'http://localhost:8000/api/v1';
+
+interface LoginPayload {
+  email: string;
+  password: string;
+}
+
+interface LoginResponse {
+  access_token: string;
+  refresh_token: string;
+  token_type: string;
+}
+
+export function useAuth() {
+  const tokens = useAuthStore((state) => state.tokens);
+  const setTokens = useAuthStore((state) => state.setTokens);
+  const clear = useAuthStore((state) => state.clear);
+
+  const login = useCallback(
+    async ({ email, password }: LoginPayload) => {
+      const response = await fetch(`${API_URL}/auth/login`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email, password }),
+      });
+
+      if (!response.ok) {
+        throw new Error('Invalid credentials');
+      }
+
+      const data: LoginResponse = await response.json();
+      setTokens({ accessToken: data.access_token, refreshToken: data.refresh_token });
+      return data;
+    },
+    [setTokens],
+  );
+
+  const refresh = useCallback(
+    async (refreshToken: string) => {
+      const response = await fetch(`${API_URL}/auth/refresh`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ refresh_token: refreshToken }),
+      });
+
+      if (!response.ok) {
+        throw new Error('Unable to refresh token');
+      }
+
+      const data: LoginResponse = await response.json();
+      setTokens({ accessToken: data.access_token, refreshToken: data.refresh_token });
+      return data;
+    },
+    [setTokens],
+  );
+
+  const logout = useCallback(() => {
+    clear();
+  }, [clear]);
+
+  const isAuthenticated = useMemo(() => Boolean(tokens?.accessToken), [tokens?.accessToken]);
+
+  return { tokens, isAuthenticated, login, refresh, logout };
+}

--- a/frontend/src/features/auth/pages/LoginPage.test.tsx
+++ b/frontend/src/features/auth/pages/LoginPage.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, expect, vi } from 'vitest';
+
+import { useAuthStore } from '../store/auth';
+import { LoginPage } from './LoginPage';
+
+declare global {
+  // eslint-disable-next-line no-var
+  var fetch: typeof window.fetch;
+}
+
+beforeEach(() => {
+  useAuthStore.setState({ tokens: null });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('LoginPage', () => {
+  it('submits credentials and stores tokens', async () => {
+    const fetchMock = vi
+      .spyOn(global, 'fetch')
+      .mockResolvedValue({
+        ok: true,
+        json: async () => ({ access_token: 'token', refresh_token: 'refresh', token_type: 'bearer' }),
+      } as unknown as Response);
+
+    render(<LoginPage />);
+
+    await userEvent.type(screen.getByLabelText(/email/i), 'admin@example.com');
+    await userEvent.type(screen.getByLabelText(/mot de passe/i), 'password');
+    await userEvent.click(screen.getByRole('button', { name: /se connecter/i }));
+
+    await waitFor(() => {
+      expect(useAuthStore.getState().tokens?.accessToken).toBe('token');
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'http://localhost:8000/api/v1/auth/login',
+      expect.objectContaining({ method: 'POST' }),
+    );
+  });
+
+  it('renders an error message when login fails', async () => {
+    vi.spyOn(global, 'fetch').mockResolvedValue({
+      ok: false,
+      json: async () => ({ message: 'error' }),
+    } as unknown as Response);
+
+    render(<LoginPage />);
+
+    await userEvent.type(screen.getByLabelText(/email/i), 'admin@example.com');
+    await userEvent.type(screen.getByLabelText(/mot de passe/i), 'password');
+    await userEvent.click(screen.getByRole('button', { name: /se connecter/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent(/invalid credentials/i);
+    });
+  });
+});

--- a/frontend/src/features/auth/pages/LoginPage.tsx
+++ b/frontend/src/features/auth/pages/LoginPage.tsx
@@ -1,0 +1,67 @@
+import { FormEvent, useState } from 'react';
+
+import { useAuth } from '../hooks/useAuth';
+
+export function LoginPage() {
+  const { login } = useAuth();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [isSubmitting, setSubmitting] = useState(false);
+
+  const onSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setError(null);
+    setSubmitting(true);
+    try {
+      await login({ email, password });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Unable to login');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <main className="mx-auto flex min-h-screen max-w-md flex-col justify-center gap-6 px-4 py-12">
+      <section className="rounded-lg border border-slate-700 bg-slate-900/60 p-6 shadow-lg">
+        <h1 className="text-2xl font-semibold text-slate-100">Connexion</h1>
+        <p className="mt-1 text-sm text-slate-400">Connectez-vous pour accéder au tableau de bord.</p>
+        <form className="mt-6 flex flex-col gap-4" onSubmit={onSubmit}>
+          <label className="flex flex-col gap-2 text-sm text-slate-200">
+            Email
+            <input
+              className="rounded-md border border-slate-700 bg-slate-950 px-3 py-2 text-base text-slate-100 focus:border-sky-500 focus:outline-none"
+              name="email"
+              type="email"
+              autoComplete="email"
+              value={email}
+              onChange={(event) => setEmail(event.target.value)}
+              required
+            />
+          </label>
+          <label className="flex flex-col gap-2 text-sm text-slate-200">
+            Mot de passe
+            <input
+              className="rounded-md border border-slate-700 bg-slate-950 px-3 py-2 text-base text-slate-100 focus:border-sky-500 focus:outline-none"
+              name="password"
+              type="password"
+              autoComplete="current-password"
+              value={password}
+              onChange={(event) => setPassword(event.target.value)}
+              required
+            />
+          </label>
+          {error ? <p className="text-sm text-red-400" role="alert">{error}</p> : null}
+          <button
+            className="rounded-md bg-sky-500 px-4 py-2 text-sm font-medium text-white transition hover:bg-sky-600 disabled:cursor-not-allowed disabled:bg-sky-500/60"
+            type="submit"
+            disabled={isSubmitting}
+          >
+            {isSubmitting ? 'Connexion...' : 'Se connecter'}
+          </button>
+        </form>
+      </section>
+    </main>
+  );
+}

--- a/frontend/src/features/auth/store/auth.ts
+++ b/frontend/src/features/auth/store/auth.ts
@@ -1,0 +1,18 @@
+import { create } from 'zustand';
+
+export interface AuthTokens {
+  accessToken: string;
+  refreshToken: string;
+}
+
+interface AuthState {
+  tokens: AuthTokens | null;
+  setTokens: (tokens: AuthTokens) => void;
+  clear: () => void;
+}
+
+export const useAuthStore = create<AuthState>((set) => ({
+  tokens: null,
+  setTokens: (tokens) => set({ tokens }),
+  clear: () => set({ tokens: null }),
+}));

--- a/tools/dev/seed.ps1
+++ b/tools/dev/seed.ps1
@@ -1,0 +1,6 @@
+param()
+
+$ErrorActionPreference = "Stop"
+
+Write-Host "Seeding admin user (email: admin@example.com)..."
+python backend/src/app/scripts/seed.py


### PR DESCRIPTION
## Summary
- implement SQLAlchemy auth models, services, dependencies, and API endpoints for JWT login/refresh flows with RBAC enforcement
- add admin seed script with PowerShell entrypoint and backend tests covering hashing, login, refresh, and protected routes
- add frontend auth store, hook, ProtectedRoute, and login page with Vitest coverage plus roadmap documentation for step 03

## Testing
- pytest backend --cov=backend/src/app --cov-report=term-missing
- pnpm --dir frontend test

Ref: docs/roadmap/step-03.md

------
https://chatgpt.com/codex/tasks/task_e_68d18fdf593c83309ce2d5f69721fe7a