### PR TITLE
fix: harden roadmap guard quoting

### DIFF
--- a/docs/guards/README.md
+++ b/docs/guards/README.md
@@ -14,3 +14,27 @@ This will:
 - update the PR body with the same reference when possible.
 
 Also ensure your PR uses the template and keeps the `Ref:` line.
+
+## Quick local validation
+
+```powershell
+$ref = 'Ref: docs/roadmap/step-02.md'
+if (-not (git log -1 --pretty=%B | Select-String -SimpleMatch $ref)) {
+  git commit --allow-empty -m $ref
+}
+
+$env:GITHUB_EVENT_NAME = 'pull_request'
+$env:PR_BODY = git log -1 --pretty=%B
+
+pwsh -File tools/guards/roadmap_guard.ps1
+```
+
+## PowerShell ParserError: Unexpected token '{'
+
+Cause: PowerShell can fail to parse format strings such as `"\"{0}\"" -f $value`.
+
+Fix: avoid `-f` and use simple interpolation instead, for example:
+
+```
+throw "Missing roadmap reference in LAST COMMIT. Expected line: '$requiredRef'"
+```

--- a/tools/guards/roadmap_guard.ps1
+++ b/tools/guards/roadmap_guard.ps1
@@ -2,20 +2,36 @@ param([switch]$Strict)
 $ErrorActionPreference = 'Stop'
 $requiredRef = 'Ref: docs/roadmap/step-02.md'
 
-function Get-LastCommitMessage { git log -1 --pretty=%B }
+function Get-LastCommitMessage {
+  git log -1 --pretty=%B
+}
+
 function Get-PRBody {
-  if ($env:PR_BODY) { return $env:PR_BODY }
-  if ($env:GITHUB_EVENT_NAME -eq 'pull_request') {
-    try { $b = gh pr view --json body -q .body 2>$null; if ($LASTEXITCODE -eq 0 -and $b) { return $b } } catch {}
+  if ($env:PR_BODY) {
+    return $env:PR_BODY
   }
+
+  if ($env:GITHUB_EVENT_NAME -eq 'pull_request') {
+    try {
+      $body = gh pr view --json body -q .body 2>$null
+      if ($LASTEXITCODE -eq 0 -and $body) {
+        return $body
+      }
+    } catch {
+    }
+  }
+
   return ''
 }
 
 $commitMessage = Get-LastCommitMessage
-if (-not $commitMessage.Contains($requiredRef)) { throw ("Missing roadmap reference in LAST COMMIT. Expected line: \"{0}\"" -f $requiredRef) }
+if ([string]::IsNullOrWhiteSpace($commitMessage) -or ($commitMessage -notlike "*${requiredRef}*")) {
+  throw "Missing roadmap reference in LAST COMMIT. Expected line: '${requiredRef}'"
+}
 
 $prBody = Get-PRBody
-if ($env:GITHUB_EVENT_NAME -eq 'pull_request' -and -not $prBody.Contains($requiredRef)) {
-  throw ("Missing roadmap reference in PR BODY. Expected line: \"{0}\"" -f $requiredRef)
+if ($env:GITHUB_EVENT_NAME -eq 'pull_request' -and ($prBody -notlike "*${requiredRef}*")) {
+  throw "Missing roadmap reference in PR BODY. Expected line: '${requiredRef}'"
 }
+
 Write-Host 'roadmap_guard OK'


### PR DESCRIPTION
## Summary
- replace roadmap guard formatting logic with quoting-safe checks and gh fallback
- document local validation workflow and guidance for PowerShell format errors

## Testing
- pwsh -File tools/guards/roadmap_guard.ps1 *(fails: pwsh is not available in the container)*

Ref: docs/roadmap/step-02.md

------
https://chatgpt.com/codex/tasks/task_e_68d2657f7bd0833090e6e3188a4f46b6